### PR TITLE
KNIG-57-Make-todo's-fields-hardness-and-scariness-unchangable-when-it's-ready

### DIFF
--- a/src/main/java/com/knighttodo/knighttodo/exception/UnchangableFieldUpdateException.java
+++ b/src/main/java/com/knighttodo/knighttodo/exception/UnchangableFieldUpdateException.java
@@ -1,8 +1,0 @@
-package com.knighttodo.knighttodo.exception;
-
-public class UnchangableFieldUpdateException extends RuntimeException {
-
-    public UnchangableFieldUpdateException(String message) {
-        super(message);
-    }
-}

--- a/src/main/java/com/knighttodo/knighttodo/exception/UnchangableFieldUpdateException.java
+++ b/src/main/java/com/knighttodo/knighttodo/exception/UnchangableFieldUpdateException.java
@@ -1,0 +1,8 @@
+package com.knighttodo.knighttodo.exception;
+
+public class UnchangableFieldUpdateException extends RuntimeException {
+
+    public UnchangableFieldUpdateException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/knighttodo/knighttodo/exception/UnchangeableFieldUpdateException.java
+++ b/src/main/java/com/knighttodo/knighttodo/exception/UnchangeableFieldUpdateException.java
@@ -1,0 +1,8 @@
+package com.knighttodo.knighttodo.exception;
+
+public class UnchangeableFieldUpdateException extends RuntimeException {
+
+    public UnchangeableFieldUpdateException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/knighttodo/knighttodo/service/impl/TodoServiceImpl.java
+++ b/src/main/java/com/knighttodo/knighttodo/service/impl/TodoServiceImpl.java
@@ -50,30 +50,17 @@ public class TodoServiceImpl implements TodoService {
     }
 
     private void checkUpdatePossibility(TodoVO todoVO, TodoVO changedTodoVO) {
-        if (todoVO.isReady()) {
-            throwIfScarinessIsUpdated(todoVO, changedTodoVO);
-            throwIfHardnessIsUpdated(todoVO, changedTodoVO);
+        if (todoVO.isReady() && isScarinessOrHardnessUpdated(todoVO, changedTodoVO)) {
+            throw new UnchangableFieldUpdateException("Can not update todo's field because todo is ready");
         }
     }
 
-    private void throwIfScarinessIsUpdated(TodoVO todoVO, TodoVO changedTodoVO) {
-        if (isScarinessUpdated(todoVO, changedTodoVO)) {
-            throw new UnchangableFieldUpdateException(String.format(
-                "Can not update scariness from %s to %s because todo is ready",
-                todoVO.getScariness(), changedTodoVO.getScariness()));
-        }
+    private boolean isScarinessOrHardnessUpdated(TodoVO todoVO, TodoVO changedTodoVO) {
+        return isScarinessUpdated(todoVO, changedTodoVO) || isHardnessUpdated(todoVO, changedTodoVO);
     }
 
     private boolean isScarinessUpdated(TodoVO todoVO, TodoVO changedTodoVO) {
         return !todoVO.getScariness().equals(changedTodoVO.getScariness());
-    }
-
-    private void throwIfHardnessIsUpdated(TodoVO todoVO, TodoVO changedTodoVO) {
-        if (isHardnessUpdated(todoVO, changedTodoVO)) {
-            throw new UnchangableFieldUpdateException(String.format(
-                "Can not update hardness from %s to %s because todo is ready",
-                todoVO.getHardness(), changedTodoVO.getHardness()));
-        }
     }
 
     private boolean isHardnessUpdated(TodoVO todoVO, TodoVO changedTodoVO) {

--- a/src/main/java/com/knighttodo/knighttodo/service/impl/TodoServiceImpl.java
+++ b/src/main/java/com/knighttodo/knighttodo/service/impl/TodoServiceImpl.java
@@ -2,7 +2,7 @@ package com.knighttodo.knighttodo.service.impl;
 
 import com.knighttodo.knighttodo.domain.TodoVO;
 import com.knighttodo.knighttodo.exception.TodoNotFoundException;
-import com.knighttodo.knighttodo.exception.UnchangableFieldUpdateException;
+import com.knighttodo.knighttodo.exception.UnchangeableFieldUpdateException;
 import com.knighttodo.knighttodo.gateway.TodoGateway;
 import com.knighttodo.knighttodo.gateway.experience.ExperienceGateway;
 import com.knighttodo.knighttodo.service.TodoBlockService;
@@ -50,21 +50,14 @@ public class TodoServiceImpl implements TodoService {
     }
 
     private void checkUpdatePossibility(TodoVO todoVO, TodoVO changedTodoVO) {
-        if (todoVO.isReady() && isScarinessOrHardnessUpdated(todoVO, changedTodoVO)) {
-            throw new UnchangableFieldUpdateException("Can not update todo's field because todo is ready");
+        if (todoVO.isReady() && isAtLeastOneUnchangeableFieldUpdated(todoVO, changedTodoVO)) {
+            throw new UnchangeableFieldUpdateException("Can not update todo's field in ready state");
         }
     }
 
-    private boolean isScarinessOrHardnessUpdated(TodoVO todoVO, TodoVO changedTodoVO) {
-        return isScarinessUpdated(todoVO, changedTodoVO) || isHardnessUpdated(todoVO, changedTodoVO);
-    }
-
-    private boolean isScarinessUpdated(TodoVO todoVO, TodoVO changedTodoVO) {
-        return !todoVO.getScariness().equals(changedTodoVO.getScariness());
-    }
-
-    private boolean isHardnessUpdated(TodoVO todoVO, TodoVO changedTodoVO) {
-        return !todoVO.getHardness().equals(changedTodoVO.getHardness());
+    private boolean isAtLeastOneUnchangeableFieldUpdated(TodoVO todoVO, TodoVO changedTodoVO) {
+        return !todoVO.getScariness().equals(changedTodoVO.getScariness())
+            || !todoVO.getHardness().equals(changedTodoVO.getHardness());
     }
 
     @Override

--- a/src/test/java/com/knighttodo/knighttodo/factories/TodoFactory.java
+++ b/src/test/java/com/knighttodo/knighttodo/factories/TodoFactory.java
@@ -88,6 +88,33 @@ public class TodoFactory {
             .build();
     }
 
+    public static UpdateTodoRequestDto updateTodoRequestReadyDto() {
+        return UpdateTodoRequestDto.builder()
+            .todoName(UPDATED_TODO_NAME)
+            .scariness(SCARINESS_TODO)
+            .hardness(HARDNESS_TODO)
+            .ready(TRUE_TODO_READY)
+            .build();
+    }
+
+    public static UpdateTodoRequestDto updateTodoRequestReadyDtoWithChangedScariness() {
+        return UpdateTodoRequestDto.builder()
+            .todoName(UPDATED_TODO_NAME)
+            .scariness(UPDATED_SCARINESS_TODO)
+            .hardness(HARDNESS_TODO)
+            .ready(TRUE_TODO_READY)
+            .build();
+    }
+
+    public static UpdateTodoRequestDto updateTodoRequestReadyDtoWithChangedHardness() {
+        return UpdateTodoRequestDto.builder()
+            .todoName(UPDATED_TODO_NAME)
+            .scariness(SCARINESS_TODO)
+            .hardness(UPDATED_HARDNESS_TODO)
+            .ready(TRUE_TODO_READY)
+            .build();
+    }
+
     public static UpdateTodoRequestDto updateTodoRequestDtoWithoutName(TodoBlock savedTodoBlock) {
         UpdateTodoRequestDto request = updateTodoRequestDto(savedTodoBlock);
         request.setTodoName(null);

--- a/src/test/java/com/knighttodo/knighttodo/integration/TodoResourceIntegrationTest.java
+++ b/src/test/java/com/knighttodo/knighttodo/integration/TodoResourceIntegrationTest.java
@@ -19,6 +19,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.fail;
+
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
@@ -275,8 +276,7 @@ public class TodoResourceIntegrationTest {
             fail("Exception was't thrown");
         } catch (Exception e) {
             assertEquals(UnchangableFieldUpdateException.class, e.getCause().getClass());
-            assertEquals(String.format("Can not update scariness from %s to %s because todo is ready",
-                                       todo.getScariness(), requestDto.getScariness()), e.getCause().getMessage());
+            assertEquals("Can not update todo's field because todo is ready", e.getCause().getMessage());
         }
         assertThat(todoRepository.findById(todo.getId()).get().getScariness()).isEqualTo(todo.getScariness());
     }
@@ -294,8 +294,7 @@ public class TodoResourceIntegrationTest {
             fail("Exception was't thrown");
         } catch (Exception e) {
             assertEquals(UnchangableFieldUpdateException.class, e.getCause().getClass());
-            assertEquals(String.format("Can not update hardness from %s to %s because todo is ready",
-                                       todo.getHardness(), requestDto.getHardness()), e.getCause().getMessage());
+            assertEquals("Can not update todo's field because todo is ready", e.getCause().getMessage());
         }
         assertThat(todoRepository.findById(todo.getId()).get().getHardness()).isEqualTo(todo.getHardness());
     }

--- a/src/test/java/com/knighttodo/knighttodo/integration/TodoResourceIntegrationTest.java
+++ b/src/test/java/com/knighttodo/knighttodo/integration/TodoResourceIntegrationTest.java
@@ -17,6 +17,8 @@ import static com.knighttodo.knighttodo.TestConstants.buildUpdateTodoReadyBaseUr
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
@@ -31,6 +33,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+import com.knighttodo.knighttodo.exception.UnchangableFieldUpdateException;
 import com.knighttodo.knighttodo.factories.TodoBlockFactory;
 import com.knighttodo.knighttodo.factories.TodoFactory;
 import com.knighttodo.knighttodo.gateway.experience.response.ExperienceResponse;
@@ -239,6 +242,62 @@ public class TodoResourceIntegrationTest {
             .content(objectMapper.writeValueAsString(requestDto))
             .contentType(MediaType.APPLICATION_JSON_VALUE))
             .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    public void updateTodo_shouldUpdateReadyTodoAndReturnIt_whenScarinessAndHardnessAreUnchanged() throws Exception {
+        TodoBlock todoBlock = todoBlockRepository.save(TodoBlockFactory.todoBlockInstance());
+        Todo todo = todoRepository.save(TodoFactory.todoWithBlockIdReadyInstance(todoBlock));
+        UpdateTodoRequestDto requestDto = TodoFactory.updateTodoRequestReadyDto();
+
+        mockMvc.perform(put(API_BASE_BLOCKS + "/" + todoBlock.getId() + API_BASE_TODOS + "/" + todo.getId())
+                            .content(objectMapper.writeValueAsString(requestDto))
+                            .contentType(MediaType.APPLICATION_JSON_VALUE))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath(buildJsonPathToTodoName()).value(requestDto.getTodoName()))
+            .andExpect(jsonPath(buildJsonPathToScariness()).value(requestDto.getScariness().toString()))
+            .andExpect(jsonPath(buildJsonPathToHardness()).value(requestDto.getHardness().toString()));
+
+        assertThat(todoRepository.findById(todo.getId()).get().getScariness()).isEqualTo(requestDto.getScariness());
+        assertThat(todoRepository.findById(todo.getId()).get().getHardness()).isEqualTo(requestDto.getHardness());
+    }
+
+    @Test
+    public void updateTodo_shouldThrowAppropriateException_whenTodoWasReadyAndScarinessWasChanged() {
+        TodoBlock todoBlock = todoBlockRepository.save(TodoBlockFactory.todoBlockInstance());
+        Todo todo = todoRepository.save(TodoFactory.todoWithBlockIdReadyInstance(todoBlock));
+        UpdateTodoRequestDto requestDto = TodoFactory.updateTodoRequestReadyDtoWithChangedScariness();
+
+        try {
+            mockMvc.perform(put(API_BASE_BLOCKS + "/" + todoBlock.getId() + API_BASE_TODOS + "/" + todo.getId())
+                                .content(objectMapper.writeValueAsString(requestDto))
+                                .contentType(MediaType.APPLICATION_JSON_VALUE));
+            fail("Exception was't thrown");
+        } catch (Exception e) {
+            assertEquals(UnchangableFieldUpdateException.class, e.getCause().getClass());
+            assertEquals(String.format("Can not update scariness from %s to %s because todo is ready",
+                                       todo.getScariness(), requestDto.getScariness()), e.getCause().getMessage());
+        }
+        assertThat(todoRepository.findById(todo.getId()).get().getScariness()).isEqualTo(todo.getScariness());
+    }
+
+    @Test
+    public void updateTodo_shouldThrowAppropriateException_whenTodoWasReadyAndHardnessWasChanged() {
+        TodoBlock todoBlock = todoBlockRepository.save(TodoBlockFactory.todoBlockInstance());
+        Todo todo = todoRepository.save(TodoFactory.todoWithBlockIdReadyInstance(todoBlock));
+        UpdateTodoRequestDto requestDto = TodoFactory.updateTodoRequestReadyDtoWithChangedHardness();
+
+        try {
+            mockMvc.perform(put(API_BASE_BLOCKS + "/" + todoBlock.getId() + API_BASE_TODOS + "/" + todo.getId())
+                                .content(objectMapper.writeValueAsString(requestDto))
+                                .contentType(MediaType.APPLICATION_JSON_VALUE));
+            fail("Exception was't thrown");
+        } catch (Exception e) {
+            assertEquals(UnchangableFieldUpdateException.class, e.getCause().getClass());
+            assertEquals(String.format("Can not update hardness from %s to %s because todo is ready",
+                                       todo.getHardness(), requestDto.getHardness()), e.getCause().getMessage());
+        }
+        assertThat(todoRepository.findById(todo.getId()).get().getHardness()).isEqualTo(todo.getHardness());
     }
 
     @Test

--- a/src/test/java/com/knighttodo/knighttodo/integration/TodoResourceIntegrationTest.java
+++ b/src/test/java/com/knighttodo/knighttodo/integration/TodoResourceIntegrationTest.java
@@ -264,7 +264,7 @@ public class TodoResourceIntegrationTest {
     }
 
     @Test
-    public void updateTodo_shouldThrowAppropriateException_whenTodoWasReadyAndScarinessWasChanged() {
+    public void updateTodo_shouldThrowUnchangeableFieldUpdateException_whenTodoWasReadyAndScarinessWasChanged() {
         TodoBlock todoBlock = todoBlockRepository.save(TodoBlockFactory.todoBlockInstance());
         Todo todo = todoRepository.save(TodoFactory.todoWithBlockIdReadyInstance(todoBlock));
         UpdateTodoRequestDto requestDto = TodoFactory.updateTodoRequestReadyDtoWithChangedScariness();
@@ -282,7 +282,7 @@ public class TodoResourceIntegrationTest {
     }
 
     @Test
-    public void updateTodo_shouldThrowAppropriateException_whenTodoWasReadyAndHardnessWasChanged() {
+    public void updateTodo_shouldThrowUnchangeableFieldUpdateException_whenTodoWasReadyAndHardnessWasChanged() {
         TodoBlock todoBlock = todoBlockRepository.save(TodoBlockFactory.todoBlockInstance());
         Todo todo = todoRepository.save(TodoFactory.todoWithBlockIdReadyInstance(todoBlock));
         UpdateTodoRequestDto requestDto = TodoFactory.updateTodoRequestReadyDtoWithChangedHardness();

--- a/src/test/java/com/knighttodo/knighttodo/integration/TodoResourceIntegrationTest.java
+++ b/src/test/java/com/knighttodo/knighttodo/integration/TodoResourceIntegrationTest.java
@@ -34,7 +34,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
-import com.knighttodo.knighttodo.exception.UnchangableFieldUpdateException;
+import com.knighttodo.knighttodo.exception.UnchangeableFieldUpdateException;
 import com.knighttodo.knighttodo.factories.TodoBlockFactory;
 import com.knighttodo.knighttodo.factories.TodoFactory;
 import com.knighttodo.knighttodo.gateway.experience.response.ExperienceResponse;
@@ -275,8 +275,8 @@ public class TodoResourceIntegrationTest {
                                 .contentType(MediaType.APPLICATION_JSON_VALUE));
             fail("Exception was't thrown");
         } catch (Exception e) {
-            assertEquals(UnchangableFieldUpdateException.class, e.getCause().getClass());
-            assertEquals("Can not update todo's field because todo is ready", e.getCause().getMessage());
+            assertEquals(UnchangeableFieldUpdateException.class, e.getCause().getClass());
+            assertEquals("Can not update todo's field in ready state", e.getCause().getMessage());
         }
         assertThat(todoRepository.findById(todo.getId()).get().getScariness()).isEqualTo(todo.getScariness());
     }
@@ -293,8 +293,8 @@ public class TodoResourceIntegrationTest {
                                 .contentType(MediaType.APPLICATION_JSON_VALUE));
             fail("Exception was't thrown");
         } catch (Exception e) {
-            assertEquals(UnchangableFieldUpdateException.class, e.getCause().getClass());
-            assertEquals("Can not update todo's field because todo is ready", e.getCause().getMessage());
+            assertEquals(UnchangeableFieldUpdateException.class, e.getCause().getClass());
+            assertEquals("Can not update todo's field in ready state", e.getCause().getMessage());
         }
         assertThat(todoRepository.findById(todo.getId()).get().getHardness()).isEqualTo(todo.getHardness());
     }


### PR DESCRIPTION
1. added throwing specific exception on attempt to change hardness or scariness of todo when it's ready
2. added 1 positive and 2 negative tests for new update ready todo cases
3. added appropriate todo factory methods