### PR TITLE
KNIG-44-Make-project-work-with-Postgres-database

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,9 +31,8 @@
             <artifactId>spring-boot-starter-data-jpa</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.h2database</groupId>
-            <artifactId>h2</artifactId>
-            <scope>runtime</scope>
+            <groupId>org.postgresql</groupId>
+            <artifactId>postgresql</artifactId>
         </dependency>
         <dependency>
             <groupId>org.projectlombok</groupId>

--- a/src/main/java/com/knighttodo/knighttodo/gateway/privatedb/representation/Block.java
+++ b/src/main/java/com/knighttodo/knighttodo/gateway/privatedb/representation/Block.java
@@ -16,7 +16,6 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
-import org.hibernate.annotations.ColumnDefault;
 import org.hibernate.annotations.GenericGenerator;
 
 @Entity
@@ -33,7 +32,6 @@ public class Block {
         name = "uuid",
         strategy = "org.hibernate.id.UUIDGenerator"
     )
-    @ColumnDefault("random_uuid()")
     @Column(name = "id")
     private String id;
 

--- a/src/main/java/com/knighttodo/knighttodo/gateway/privatedb/representation/Todo.java
+++ b/src/main/java/com/knighttodo/knighttodo/gateway/privatedb/representation/Todo.java
@@ -7,7 +7,6 @@ import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
-import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
@@ -20,7 +19,6 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
 
-import org.hibernate.annotations.ColumnDefault;
 import org.hibernate.annotations.GenericGenerator;
 
 @Entity
@@ -38,7 +36,6 @@ public class Todo {
         name = "uuid",
         strategy = "org.hibernate.id.UUIDGenerator"
     )
-    @ColumnDefault("random_uuid()")
     @Column(name = "id")
     private String id;
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,4 +1,6 @@
-spring:
-  datasource:
-    type:com.zaxxer.hikari.HikariDataSource
-    url:jdbc:h2:mem:demo;DB_CLOSE_DELAY=-1
+spring.datasource.url=jdbc:postgresql://localhost/knight
+spring.datasource.username=${db.username}
+spring.datasource.password=${db.password}
+spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQL10Dialect
+
+spring.jpa.hibernate.ddl-auto=update

--- a/src/test/java/com/knighttodo/knighttodo/integration/BlockResourceIntegrationTest.java
+++ b/src/test/java/com/knighttodo/knighttodo/integration/BlockResourceIntegrationTest.java
@@ -37,7 +37,7 @@ import com.knighttodo.knighttodo.gateway.privatedb.representation.Todo;
 import com.knighttodo.knighttodo.rest.request.BlockRequestDto;
 
 import java.util.List;
-import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.beans.factory.annotation.Autowired;
@@ -66,8 +66,8 @@ public class BlockResourceIntegrationTest {
     @Autowired
     private TodoRepository todoRepository;
 
-    @BeforeEach
-    public void setUp() {
+    @AfterEach
+    public void tearDown() {
         blockRepository.deleteAll();
     }
 

--- a/src/test/java/com/knighttodo/knighttodo/integration/RoutineResourceIntegrationTest.java
+++ b/src/test/java/com/knighttodo/knighttodo/integration/RoutineResourceIntegrationTest.java
@@ -35,7 +35,7 @@ import com.knighttodo.knighttodo.gateway.privatedb.representation.Todo;
 import com.knighttodo.knighttodo.rest.request.RoutineRequestDto;
 
 import java.util.List;
-import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.beans.factory.annotation.Autowired;
@@ -63,8 +63,8 @@ public class RoutineResourceIntegrationTest {
     @Autowired
     private TodoRepository todoRepository;
 
-    @BeforeEach
-    public void setUp() {
+    @AfterEach
+    public void tearDown() {
         todoRepository.deleteAll();
         routineRepository.deleteAll();
         blockRepository.deleteAll();

--- a/src/test/java/com/knighttodo/knighttodo/integration/TodoResourceIntegrationTest.java
+++ b/src/test/java/com/knighttodo/knighttodo/integration/TodoResourceIntegrationTest.java
@@ -17,13 +17,18 @@ import static com.knighttodo.knighttodo.TestConstants.buildJsonPathToReadyName;
 import static com.knighttodo.knighttodo.TestConstants.buildJsonPathToScariness;
 import static com.knighttodo.knighttodo.TestConstants.buildJsonPathToTodoName;
 import static com.knighttodo.knighttodo.TestConstants.buildUpdateTodoReadyBaseUrl;
+
 import static org.aspectj.bridge.MessageUtil.fail;
+
 import static org.assertj.core.api.Assertions.assertThat;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
+
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -32,6 +37,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+
 import com.knighttodo.knighttodo.exception.UnchangeableFieldUpdateException;
 import com.knighttodo.knighttodo.factories.BlockFactory;
 import com.knighttodo.knighttodo.factories.TodoFactory;
@@ -41,8 +47,10 @@ import com.knighttodo.knighttodo.gateway.privatedb.repository.TodoRepository;
 import com.knighttodo.knighttodo.gateway.privatedb.representation.Block;
 import com.knighttodo.knighttodo.gateway.privatedb.representation.Todo;
 import com.knighttodo.knighttodo.rest.request.TodoRequestDto;
-import org.junit.jupiter.api.BeforeEach;
+
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -77,8 +85,8 @@ public class TodoResourceIntegrationTest {
     @Value("${baseUrl.experience}")
     private String experienceUrl;
 
-    @BeforeEach
-    public void setUp() {
+    @AfterEach
+    public void tearDown() {
         todoRepository.deleteAll();
         blockRepository.deleteAll();
     }

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -1,0 +1,7 @@
+spring.datasource.url=jdbc:postgresql://localhost/knight-test
+spring.datasource.username=${test.db.username}
+spring.datasource.password=${test.db.password}
+spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQL10Dialect
+
+spring.jpa.hibernate.ddl-auto=create
+spring.jpa.show-sql=true


### PR DESCRIPTION
1. added postgresql support to microservice
2. removed h2 support from microservice
3. removed redundant column defaults from entities because it is not necessary and not supported by postgresql
4. removed redundant imports from entities
5. replaced all beforeEach methods in tests with afterEach to clean a db after tests
6.fixed vertical indents in todo resource integration tests imports
7. hid db passwords and usernames